### PR TITLE
fix multiple identity columns bug

### DIFF
--- a/acceptance_test.go
+++ b/acceptance_test.go
@@ -147,9 +147,6 @@ func prepareData(t *testing.T, cfg map[string]string) error {
 
 		// check if table exist.
 		rows, er := db.Query(queryIfExistTable, cfg[config.KeyTable])
-		if rows.Err() != nil {
-			t.Error(rows.Err())
-		}
 		if er != nil {
 			t.Error(er)
 		}
@@ -170,6 +167,9 @@ func prepareData(t *testing.T, cfg map[string]string) error {
 					t.Errorf("drop test tracking table: %v", err)
 				}
 			}
+		}
+		if rows.Err() != nil {
+			t.Error(rows.Err())
 		}
 
 		if err = db.Close(); err != nil {

--- a/columntypes/columntypes.go
+++ b/columntypes/columntypes.go
@@ -173,9 +173,6 @@ func ConvertStructureData(
 // GetColumnTypes returns a map containing all table's columns and their database types.
 func GetColumnTypes(ctx context.Context, querier Querier, tableName string) (map[string]string, error) {
 	rows, err := querier.QueryContext(ctx, fmt.Sprintf(querySchemaColumnTypes, tableName))
-	if rows.Err() != nil {
-		return nil, fmt.Errorf("query column types: %w", rows.Err())
-	}
 	if err != nil {
 		return nil, fmt.Errorf("query column types: %w", err)
 	}
@@ -189,6 +186,9 @@ func GetColumnTypes(ctx context.Context, querier Querier, tableName string) (map
 		}
 
 		columnTypes[columnName] = dataType
+	}
+	if rows.Err() != nil {
+		return nil, fmt.Errorf("iterate rows error: %w", rows.Err())
 	}
 
 	return columnTypes, nil

--- a/source/iterator/queries.go
+++ b/source/iterator/queries.go
@@ -22,8 +22,6 @@ const (
 										WHERE TABLE_TYPE = 'BASE TABLE'
 										AND TABLE_NAME = ?`
 
-	queryCreateTrackingTable = `SELECT TOP 0 * INTO %s FROM %s`
-
 	queryAddOperationTypeColumn = `ALTER TABLE %s ADD %s VARCHAR (10)`
 
 	queryAddODateTimeColumn = `ALTER TABLE %s ADD %s datetime default getDate()`
@@ -61,6 +59,11 @@ const (
 		  CONSTRAINT_TYPE = 'PRIMARY KEY' 
 		  AND TABLE_NAME = '%s'
 	  )
-
 `
+
+	queryGetColumnsInfo = `
+		SELECT COLUMN_NAME, DATA_TYPE, CHARACTER_MAXIMUM_LENGTH, NUMERIC_PRECISION, NUMERIC_SCALE
+		FROM INFORMATION_SCHEMA.COLUMNS
+		WHERE TABLE_NAME = ?;
+	`
 )


### PR DESCRIPTION
### Description

the old query to create the tracking table used to copy over restrictions like "identity", which resulted in multiple identity columns when trying to add an identity column to the tracking table.
the solution was creating the tracking table by getting the columns info for the source table.

Fixes #54 

### Quick checks:

- [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [ ] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-snowflake/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.
